### PR TITLE
fix: bind to 127.0.0.1 instead of 0.0.0.0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ if (isNaN(port)) {
 
 const app = createServer();
 
-const server = app.listen(port, async () => {
+const server = app.listen(port, '127.0.0.1', async () => {
   const url = `http://localhost:${port}`;
   console.log(`\n  claude-spend dashboard running at ${url}\n`);
 


### PR DESCRIPTION
Binding to 0.0.0.0 exposes your instance to anyone on the network (if you're in a coffee shop). 

127.0.0.1 prevents that exposure.

Closes #10 