### PR TITLE
fix: add Opus 4.7 pricing ($5/$25) — currently billed at 3× actual rate

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -7,9 +7,10 @@ const readline = require('readline');
 // Note: These are API-equivalent estimates. Claude Code subscription pricing differs.
 // Cache write = 1.25x base input (5-min TTL). Cache read = 0.1x base input.
 const MODEL_PRICING = {
-  // Opus 4.5, 4.6: $5/MTok in, $25/MTok out
+  // Opus 4.5, 4.6, 4.7: $5/MTok in, $25/MTok out
   'opus-4.5': { input: 5 / 1e6, output: 25 / 1e6, cacheWrite: 6.25 / 1e6, cacheRead: 0.50 / 1e6 },
   'opus-4.6': { input: 5 / 1e6, output: 25 / 1e6, cacheWrite: 6.25 / 1e6, cacheRead: 0.50 / 1e6 },
+  'opus-4.7': { input: 5 / 1e6, output: 25 / 1e6, cacheWrite: 6.25 / 1e6, cacheRead: 0.50 / 1e6 },
   // Opus 4.0, 4.1: $15/MTok in, $75/MTok out
   'opus-4.0': { input: 15 / 1e6, output: 75 / 1e6, cacheWrite: 18.75 / 1e6, cacheRead: 1.50 / 1e6 },
   'opus-4.1': { input: 15 / 1e6, output: 75 / 1e6, cacheWrite: 18.75 / 1e6, cacheRead: 1.50 / 1e6 },
@@ -26,7 +27,8 @@ function getPricing(model) {
   if (!model) return DEFAULT_PRICING;
   const m = model.toLowerCase();
   if (m.includes('opus')) {
-    // Opus 4.5/4.6 are cheaper than Opus 4.0/4.1
+    // Opus 4.5/4.6/4.7 are cheaper than Opus 4.0/4.1
+    if (m.includes('4-7') || m.includes('4.7')) return MODEL_PRICING['opus-4.7'];
     if (m.includes('4-6') || m.includes('4.6')) return MODEL_PRICING['opus-4.6'];
     if (m.includes('4-5') || m.includes('4.5')) return MODEL_PRICING['opus-4.5'];
     if (m.includes('4-1') || m.includes('4.1')) return MODEL_PRICING['opus-4.1'];


### PR DESCRIPTION
## Problem

`getPricing()` in `src/parser.js` has branches for Opus 4-6 / 4-5 / 4-1 but any other Opus variant — including the recently released **4.7** — falls through to the Opus 4.0 branch (`\$15/\$75` per MTok).

This means Opus 4.7 usage is currently reported at **~3× the actual cost**:

| | input | output |
|---|---|---|
| Currently reported | \$15 / MTok | \$75 / MTok |
| Actual rate | \$5 / MTok | \$25 / MTok |

## Source of truth

Per Anthropic's official pricing page (https://platform.claude.com/docs/en/about-claude/pricing), Opus 4.7 matches the 4.5 / 4.6 pricing tier:

| Model | Base Input | 5m Cache Write | 1h Cache Write | Cache Read | Output |
|---|---|---|---|---|---|
| Claude Opus 4.7 | \$5 / MTok | \$6.25 / MTok | \$10 / MTok | \$0.50 / MTok | \$25 / MTok |
| Claude Opus 4.6 | \$5 / MTok | \$6.25 / MTok | \$10 / MTok | \$0.50 / MTok | \$25 / MTok |
| Claude Opus 4.5 | \$5 / MTok | \$6.25 / MTok | \$10 / MTok | \$0.50 / MTok | \$25 / MTok |

The docs also note Opus 4.7 uses a new tokenizer that may consume up to 35% more tokens for the same fixed text, but this affects token counts (already recorded correctly in the session logs), not per-token rates — no other adjustment needed.

## Change

- Add `'opus-4.7'` entry to `MODEL_PRICING` (same rates as 4.5 / 4.6)
- Add `4-7` / `4.7` branch in `getPricing()` above the 4-6 check

Follows the existing style. 4 lines added, 2 comment lines updated. No behavioral change for any other model.

## Verification

Tested against the patched parser:

\`\`\`
claude-opus-4-7    input \$5.00/MTok   output \$25.00/MTok   ← was \$15 / \$75
claude-opus-4-6    input \$5.00/MTok   output \$25.00/MTok
claude-opus-4-1    input \$15.00/MTok  output \$75.00/MTok
claude-sonnet-4-6  input \$3.00/MTok   output \$15.00/MTok
claude-haiku-4-5   input \$1.00/MTok   output \$5.00/MTok
\`\`\`