### PR TITLE
fix: don't undercount sessions with subagents or 1h cache writes

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -5,20 +5,21 @@ const readline = require('readline');
 
 // Anthropic API pricing per token (from platform.claude.com/docs/en/about-claude/pricing)
 // Note: These are API-equivalent estimates. Claude Code subscription pricing differs.
-// Cache write = 1.25x base input (5-min TTL). Cache read = 0.1x base input.
+// Cache writes have two tiers: 5-min TTL (1.25x base input) and 1-hour TTL (2x base input).
+// Cache read = 0.1x base input.
 const MODEL_PRICING = {
-  // Opus 4.5, 4.6: $5/MTok in, $25/MTok out
-  'opus-4.5': { input: 5 / 1e6, output: 25 / 1e6, cacheWrite: 6.25 / 1e6, cacheRead: 0.50 / 1e6 },
-  'opus-4.6': { input: 5 / 1e6, output: 25 / 1e6, cacheWrite: 6.25 / 1e6, cacheRead: 0.50 / 1e6 },
-  // Opus 4.0, 4.1: $15/MTok in, $75/MTok out
-  'opus-4.0': { input: 15 / 1e6, output: 75 / 1e6, cacheWrite: 18.75 / 1e6, cacheRead: 1.50 / 1e6 },
-  'opus-4.1': { input: 15 / 1e6, output: 75 / 1e6, cacheWrite: 18.75 / 1e6, cacheRead: 1.50 / 1e6 },
-  // Sonnet 3.7, 4, 4.5, 4.6: $3/MTok in, $15/MTok out
-  sonnet: { input: 3 / 1e6, output: 15 / 1e6, cacheWrite: 3.75 / 1e6, cacheRead: 0.30 / 1e6 },
-  // Haiku 4.5: $1/MTok in, $5/MTok out
-  'haiku-4.5': { input: 1 / 1e6, output: 5 / 1e6, cacheWrite: 1.25 / 1e6, cacheRead: 0.10 / 1e6 },
-  // Haiku 3.5: $0.80/MTok in, $4/MTok out
-  'haiku-3.5': { input: 0.80 / 1e6, output: 4 / 1e6, cacheWrite: 1.00 / 1e6, cacheRead: 0.08 / 1e6 },
+  // Opus 4.5, 4.6: $5/MTok in, $25/MTok out; 5m cache $6.25, 1h cache $10
+  'opus-4.5': { input: 5 / 1e6, output: 25 / 1e6, cacheWrite: 6.25 / 1e6, cacheWrite1h: 10 / 1e6, cacheRead: 0.50 / 1e6 },
+  'opus-4.6': { input: 5 / 1e6, output: 25 / 1e6, cacheWrite: 6.25 / 1e6, cacheWrite1h: 10 / 1e6, cacheRead: 0.50 / 1e6 },
+  // Opus 4.0, 4.1: $15/MTok in, $75/MTok out; 5m cache $18.75, 1h cache $30
+  'opus-4.0': { input: 15 / 1e6, output: 75 / 1e6, cacheWrite: 18.75 / 1e6, cacheWrite1h: 30 / 1e6, cacheRead: 1.50 / 1e6 },
+  'opus-4.1': { input: 15 / 1e6, output: 75 / 1e6, cacheWrite: 18.75 / 1e6, cacheWrite1h: 30 / 1e6, cacheRead: 1.50 / 1e6 },
+  // Sonnet 3.7, 4, 4.5, 4.6: $3/MTok in, $15/MTok out; 5m cache $3.75, 1h cache $6
+  sonnet: { input: 3 / 1e6, output: 15 / 1e6, cacheWrite: 3.75 / 1e6, cacheWrite1h: 6 / 1e6, cacheRead: 0.30 / 1e6 },
+  // Haiku 4.5: $1/MTok in, $5/MTok out; 5m cache $1.25, 1h cache $2
+  'haiku-4.5': { input: 1 / 1e6, output: 5 / 1e6, cacheWrite: 1.25 / 1e6, cacheWrite1h: 2 / 1e6, cacheRead: 0.10 / 1e6 },
+  // Haiku 3.5: $0.80/MTok in, $4/MTok out; 5m cache $1.00, 1h cache $1.6
+  'haiku-3.5': { input: 0.80 / 1e6, output: 4 / 1e6, cacheWrite: 1.00 / 1e6, cacheWrite1h: 1.6 / 1e6, cacheRead: 0.08 / 1e6 },
 };
 const DEFAULT_PRICING = MODEL_PRICING.sonnet;
 
@@ -93,8 +94,17 @@ function extractSessionData(entries) {
       const cacheReadTokens = usage.cache_read_input_tokens || 0;
       const outputTokens = usage.output_tokens || 0;
       const totalTokens = inputTokens + cacheCreationTokens + cacheReadTokens + outputTokens;
+      // Split cache_creation by TTL when the breakdown is present (post-2025 Q4 API).
+      // Fallback: only the rolled-up legacy field exists -> treat all as 5-minute writes.
+      const cc = usage.cache_creation || {};
+      const has5m = cc.ephemeral_5m_input_tokens !== undefined;
+      const has1h = cc.ephemeral_1h_input_tokens !== undefined;
+      const cw5m = has5m ? cc.ephemeral_5m_input_tokens : (has1h ? 0 : cacheCreationTokens);
+      const cw1h = has1h ? cc.ephemeral_1h_input_tokens : 0;
+      const cw1hRate = pricing.cacheWrite1h ?? pricing.cacheWrite;
       const cost = (inputTokens * pricing.input)
-        + (cacheCreationTokens * pricing.cacheWrite)
+        + (cw5m * pricing.cacheWrite)
+        + (cw1h * cw1hRate)
         + (cacheReadTokens * pricing.cacheRead)
         + (outputTokens * pricing.output);
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -164,17 +164,42 @@ async function parseAllSessions() {
   const modelMap = {};
   const allPrompts = []; // for "most expensive prompts" across all sessions
 
+  // Recursively walk the project dir so subagent transcripts at
+  // `<project>/<session-id>/subagents/agent-*.jsonl` are picked up too.
+  // Without this, sessions that use the Task tool / subagents undercount
+  // their token usage by ~30%, since subagent transcripts live one level
+  // deeper than the readdirSync default scan.
+  function findJsonlRecursive(rootDir) {
+    const found = [];
+    const stack = [rootDir];
+    while (stack.length) {
+      const cur = stack.pop();
+      let entries;
+      try {
+        entries = fs.readdirSync(cur, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      for (const ent of entries) {
+        const full = path.join(cur, ent.name);
+        if (ent.isDirectory()) stack.push(full);
+        else if (ent.isFile() && ent.name.endsWith('.jsonl')) found.push(full);
+      }
+    }
+    return found;
+  }
+
   for (const projectDir of projectDirs) {
     const dir = path.join(projectsDir, projectDir);
     let files;
     try {
-      files = fs.readdirSync(dir).filter(f => f.endsWith('.jsonl'));
+      files = findJsonlRecursive(dir);
     } catch {
       continue; // Skip directories we can't read
     }
 
     for (const file of files) {
-      const filePath = path.join(dir, file);
+      const filePath = file; // findJsonlRecursive returns absolute paths
       const sessionId = path.basename(file, '.jsonl');
 
       let entries;


### PR DESCRIPTION
Two independent fixes for systematic cost undercounts. Each commit stands on its own; happy to split into two PRs if that's preferred.

## 1. Recurse into subagent subdirectories (`08be42c`)

`fs.readdirSync(dir)` only enumerates the top level of each project directory, but Claude Code stores subagent transcripts at `<project>/<session-id>/subagents/agent-*.jsonl` — one level deeper. Any session that uses the Task tool / subagents has its transcripts silently dropped from the totals.

For Task-heavy workflows (research / multi-step tasks), this typically excludes ~30% of input/output/cache tokens, and therefore ~30% of the displayed cost.

Replaced with an iterative walker that picks up every `.jsonl` under the project tree. Each subagent transcript is treated as its own session row, keyed by the agent file name.

## 2. Price 1-hour cache writes at 2x base, not the 5-minute rate (`d34ba8e`)

Anthropic charges two tiers for prompt-cache writes:
- 5-minute TTL: 1.25x base input price
- **1-hour TTL: 2x base input price** (60% more per token)

The current `cacheWrite` field in `MODEL_PRICING` bakes in the 5-minute rate and applies it to every cache write regardless of TTL.

The Anthropic API has been returning `usage.cache_creation` with `ephemeral_5m_input_tokens` and `ephemeral_1h_input_tokens` separately since late 2025, alongside the legacy rolled-up `cache_creation_input_tokens`. Claude Code in particular pins the system prompt and CLAUDE.md context into the 1-hour bucket — long sessions can run >95% 1-hour writes — so a uniform 5-minute rate understates cache-write cost significantly.

Added a `cacheWrite1h` rate per model entry, and split cache-write tokens by TTL when the breakdown is present. Sessions whose JSONL only carries the legacy rolled-up field continue to be priced at the 5-minute rate — no regression for older logs.

Reference: <https://platform.claude.com/docs/en/about-claude/pricing>

## Combined impact

On a representative long-running set of sessions (substantial subagent and 1-hour cache use), these two fixes raised the reported cost by roughly 35% — closing most of the gap between what `claude-spend` shows and what the Anthropic Console bills.